### PR TITLE
hotfix(interactions): Import ObjectHandler in production entrypoint

### DIFF
--- a/index.render-final.js
+++ b/index.render-final.js
@@ -5,6 +5,7 @@ const express = require('express');
 const deploymentManager = require('./utils/deploymentManager');
 const mongoBackup = require('./utils/mongoBackupManager');
 const levelManager = require('./utils/levelManager');
+const { handleObjectInteraction } = require('./handlers/ObjectHandler');
 
 // Handlers pour les nouvelles fonctionnalités karma
 async function handleKarmaResetComplete(interaction) {


### PR DESCRIPTION
The previous fix was applied to `index.js`, but the production environment runs `index.render-final.js`, which was missing the required import for `handleObjectInteraction`.

This caused a reference error when the existing routing logic for the `/objet` command was triggered.

This commit adds the necessary `require('./handlers/ObjectHandler')` to `index.render-final.js`, making the function available and resolving the interaction error in the production environment.