### PR TITLE
refactor(data): Remove duplicate methods in SimpleDataManager

### DIFF
--- a/utils/simpleDataManager.js
+++ b/utils/simpleDataManager.js
@@ -112,16 +112,6 @@ class SimpleDataManager {
         this.setData('economy.json', economy);
     }
 
-    // Sauvegarder (fichiers locaux uniquement)
-    async saveData(filename, data) {
-        this.setData(filename, data);
-    }
-
-    // Charger (fichiers locaux uniquement)
-    async loadData(filename, defaultValue = {}) {
-        const data = this.getData(filename);
-        return Object.keys(data).length === 0 ? defaultValue : data;
-    }
 }
 
 module.exports = new SimpleDataManager();


### PR DESCRIPTION
The `SimpleDataManager` class had `saveData` and `loadData` methods defined twice. The second, simpler definitions were overwriting the first, more complete ones.

This prevented the `dataHooks.triggerBackup` from being called, potentially causing data inconsistency with MongoDB backups.

This commit removes the duplicate methods, ensuring the correct versions are used throughout the application. This improves data integrity and may resolve subtle bugs related to data handling during interactions.