### PR TITLE
Fix command not opening objects

### DIFF
--- a/commands/boutique.js
+++ b/commands/boutique.js
@@ -104,10 +104,13 @@ module.exports = {
                             const priceDisplay = karmaDiscountPercent > 0 ? 
                                 `${finalPrice}€ (était ${item.price}€)` : `${item.price}€`;
 
+                            // Ensure unique value - use item.id if available, otherwise create unique identifier
+                            const uniqueValue = item.id ? item.id.toString() : `shop_item_${index}_${Date.now().toString(36)}`;
+
                             return {
                                 label: item.name,
                                 description: `${priceDisplay} - ${(item.description || 'Aucune description').substring(0, 60)}`,
-                                value: (item.id || index).toString(),
+                                value: uniqueValue,
                                 emoji: emoji
                             };
                         })

--- a/commands/objet.js
+++ b/commands/objet.js
@@ -52,9 +52,9 @@ module.exports = {
             .setCustomId('object_selection')
             .setPlaceholder('Choisissez un objet...')
             .addOptions(
-                customObjects.map(item => ({
+                customObjects.map((item, index) => ({
                     label: item.name,
-                    value: item.id.toString(), // Utiliser l'ID unique de l'objet
+                    value: `${item.id || index}_${index}`, // Ensure unique value by combining ID and index
                     description: item.description || 'Objet personnalisé',
                     emoji: getItemEmoji(item.type)
                 }))

--- a/handlers/ObjectHandler.js
+++ b/handlers/ObjectHandler.js
@@ -12,8 +12,10 @@ async function handleObjectInteraction(interaction, dataManager) {
 
         // --- Step 1: User selects an object ---
         if (customId === 'object_selection') {
-            const objectId = interaction.values[0];
-            const obj = userData.inventory.find(item => item.id.toString() === objectId);
+            const objectValue = interaction.values[0];
+            // Extract the original ID from the combined value (objectId_index)
+            const originalObjectId = objectValue.split('_')[0];
+            const obj = userData.inventory.find(item => (item.id || '').toString() === originalObjectId);
 
             if (!obj) {
                 return await interaction.update({ content: '❌ Objet introuvable ou expiré.', components: [] });

--- a/index.render-final.js
+++ b/index.render-final.js
@@ -2265,7 +2265,19 @@ async function handleShopPurchase(interaction, dataManager) {
         const shopItems = shopData[guildId] || [];
 
         // Trouver l'objet sélectionné
-        const item = shopItems.find(i => (i.id || shopItems.indexOf(i)).toString() === itemId);
+        let item;
+        if (itemId.startsWith('shop_item_')) {
+            // Handle new generated identifiers - extract index
+            const indexMatch = itemId.match(/shop_item_(\d+)_/);
+            if (indexMatch) {
+                const itemIndex = parseInt(indexMatch[1]);
+                item = shopItems[itemIndex];
+            }
+        } else {
+            // Handle original item IDs or direct index
+            item = shopItems.find(i => (i.id || shopItems.indexOf(i)).toString() === itemId);
+        }
+        
         if (!item) {
             return await interaction.reply({
                 content: '❌ Objet introuvable dans la boutique.',
@@ -2303,8 +2315,11 @@ async function handleShopPurchase(interaction, dataManager) {
         // Ajouter l'objet à l'inventaire
         if (!userData.inventory) userData.inventory = [];
         
+        // Generate a truly unique ID
+        const uniqueId = item.id || `${Date.now()}_${Math.random().toString(36).substr(2, 9)}_${userId.slice(-4)}`;
+        
         const inventoryItem = {
-            id: item.id || Date.now().toString(),
+            id: uniqueId,
             name: item.name,
             description: item.description || 'Objet de la boutique',
             type: item.type || 'custom',


### PR DESCRIPTION
Fixes `DiscordAPIError[50035]` and allows object commands to function by ensuring unique IDs for items in select menus and inventory.

The error `SELECT_COMPONENT_OPTION_VALUE_DUPLICATED` occurred because item identifiers generated for Discord select menu options (e.g., in `/objet` command) or for items added to inventory (e.g., from `/boutique` command) were not consistently unique. This PR modifies the ID generation logic to guarantee uniqueness, resolving the API error and enabling proper object interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-4069db6c-9214-4759-8720-d817b9870315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4069db6c-9214-4759-8720-d817b9870315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>