### PR TITLE
Add member choice before modal

### DIFF
--- a/handlers/ObjectHandler.js
+++ b/handlers/ObjectHandler.js
@@ -126,21 +126,13 @@ async function handleObjectInteraction(interaction, dataManager) {
             const objectId = customId.replace('custom_message_modal_', '');
             const message = interaction.fields.getTextInputValue('custom_message');
 
-            const members = (await interaction.guild.members.fetch()).filter(m => !m.user.bot);
-            if (members.size === 0) return await interaction.reply({ content: '❌ Aucun membre à cibler.', ephemeral: true });
-
             // Temporary storage for the message content
             interaction.client.tempStore = interaction.client.tempStore || {};
             interaction.client.tempStore[`${userId}_${objectId}`] = message;
 
-            const userSelect = new StringSelectMenuBuilder()
+            const userSelect = new UserSelectMenuBuilder()
                 .setCustomId(`custom_user_select_${objectId}`)
-                .setPlaceholder('Choisissez un utilisateur à cibler')
-                .addOptions(members.map(m => ({ 
-                    label: m.user.username, 
-                    value: m.id,
-                    description: m.user.tag
-                })).slice(0, 25));
+                .setPlaceholder('Choisissez un utilisateur à cibler');
 
             return await interaction.reply({
                 content: 'À qui voulez-vous envoyer cette interaction ?',
@@ -152,7 +144,7 @@ async function handleObjectInteraction(interaction, dataManager) {
         // --- Step 4: Finalizing the custom message action ---
         if (customId.startsWith('custom_user_select_')) {
             const objectId = customId.replace('custom_user_select_', '');
-            const targetId = interaction.values[0];
+            const targetId = interaction.users.first().id;
             const selectedObject = userData.inventory.find(item => item.id.toString() === objectId);
 
             if (!selectedObject) return await interaction.update({ content: '❌ Objet introuvable ou expiré.', components:[], embeds: []});

--- a/utils/modalHandler.js
+++ b/utils/modalHandler.js
@@ -16,7 +16,8 @@ class ModalHandler {
             'message_limits_modal',
             'karma_levels_modal',
             'create_positive_reward_modal',
-            'create_negative_reward_modal'
+            'create_negative_reward_modal',
+            'custom_message_modal'
         ]);
 
         // Liste des modals prévues mais non implémentées


### PR DESCRIPTION
Implement native Discord user selection and register `custom_message_modal` to fix interaction errors and improve the custom message workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-0083fb90-cf6b-441e-b6a4-5098e5b97b75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0083fb90-cf6b-441e-b6a4-5098e5b97b75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>