### PR TITLE
Investigate recurring error message

### DIFF
--- a/handlers/MainRouterHandler.js
+++ b/handlers/MainRouterHandler.js
@@ -20,6 +20,7 @@ class MainRouterHandler {
         const AutoThreadConfigHandler = require('./AutoThreadConfigHandler');
         const CountingConfigHandler = require('./CountingConfigHandler');
         const DashboardHandler = require('./DashboardHandler');
+        const ObjectHandler = require('./ObjectHandler');
 
         // Import du ConfessionHandler original pour les méthodes complètes
         const ConfessionHandler = require('./ConfessionHandler');
@@ -29,7 +30,8 @@ class MainRouterHandler {
             economy: new EconomyConfigHandler(this.dataManager),
             autothread: new AutoThreadConfigHandler(this.dataManager),
             counting: new CountingConfigHandler(this.dataManager),
-            dashboard: new DashboardHandler(this.dataManager)
+            dashboard: new DashboardHandler(this.dataManager),
+            object: ObjectHandler // L'ObjectHandler est une fonction, pas une classe
         };
     }
 
@@ -155,6 +157,17 @@ class MainRouterHandler {
                     await handler.handleKarmaDiscountsInteraction(interaction);
                 }
                 return true;
+            }
+
+            // Routes pour les objets personnalisés
+            if (customId === 'object_selection' ||
+                customId.startsWith('object_action_menu_') ||
+                customId.startsWith('offer_user_select_') ||
+                customId.startsWith('confirm_delete_') ||
+                customId.startsWith('use_user_select_') || 
+                customId.startsWith('custom_message_modal_')) {
+                console.log(`➡️ Routage vers ObjectHandler: ${customId}`);
+                return await this.routeToObjectHandler(interaction, customId);
             }
 
             // Routes spéciales pour les commandes principales
@@ -814,6 +827,16 @@ class MainRouterHandler {
                 console.log(`CustomId dashboard non géré: ${customId}`);
                 return false;
         }
+    }
+
+    /**
+     * Router vers le handler des objets
+     */
+    async routeToObjectHandler(interaction, customId) {
+        const objectHandler = this.handlers.object;
+        
+        // Déléguer toutes les interactions d'objets au ObjectHandler (fonction)
+        return await objectHandler.handleObjectInteraction(interaction, this.dataManager);
     }
 
     /**


### PR DESCRIPTION
Route object-related custom IDs to `ObjectHandler` to fix "CustomId non géré" errors.

The `custom_message_modal_*` interactions, generated by the `ObjectHandler`, were not being delegated by the `MainRouterHandler`, causing the bot to report an unhandled custom ID. This PR adds the necessary routing logic for all object-related custom IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-afbaf1ed-c7d7-47c1-8f9b-557858b9ee3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afbaf1ed-c7d7-47c1-8f9b-557858b9ee3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>