### PR TITLE
Fix modals display in config and boutique

### DIFF
--- a/utils/modalHandler.js
+++ b/utils/modalHandler.js
@@ -18,7 +18,8 @@ class ModalHandler {
             'create_positive_reward_modal',
             'create_negative_reward_modal',
             'custom_message_modal',
-            'edit_item_modal'
+            'edit_item_modal',
+            'modify_reward_modal'
         ]);
 
         // Liste des modals prévues mais non implémentées

--- a/utils/modalHandler.js
+++ b/utils/modalHandler.js
@@ -17,7 +17,8 @@ class ModalHandler {
             'karma_levels_modal',
             'create_positive_reward_modal',
             'create_negative_reward_modal',
-            'custom_message_modal'
+            'custom_message_modal',
+            'edit_item_modal'
         ]);
 
         // Liste des modals prévues mais non implémentées


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `edit_item_modal` to the list of implemented modals to fix the "en développement" message on submission.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `edit_item_modal` was already implemented but was not registered in the `modalHandler.js`'s list of known modals. This caused the system to display the default "en développement" message upon submission, as it didn't recognize the modal as handled. Adding it to the list resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b48473a-47f3-4a01-ae76-de837d523e8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b48473a-47f3-4a01-ae76-de837d523e8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>