### PR TITLE
Personnaliser les messages de commande objet

### DIFF
--- a/handlers/ObjectHandler.js
+++ b/handlers/ObjectHandler.js
@@ -194,24 +194,25 @@ async function handleObjectInteraction(interaction, dataManager) {
 
             try {
                 const targetMember = await interaction.guild.members.fetch(targetId);
-                const objetCommand = require('../commands/objet');
 
-                // Déférer la réponse pour qu'elle soit visible par tous
-                await interaction.deferReply({ ephemeral: false });
-                await objetCommand.executeCustomInteraction(interaction, dataManager, selectedObject, message, targetMember);
+                // Créer le message texte simple : nom du membre + texte personnalisé + objet + ping du membre
+                const messageContent = `**${interaction.user.displayName}** ${message} **${selectedObject.name}** <@${targetId}>`;
+                
+                // Répondre directement avec le message personnalisé (non éphémère pour que le ping soit visible)
+                await interaction.reply({
+                    content: messageContent
+                });
 
                 // Nettoyer le stockage temporaire
                 delete interaction.client.tempStore[`${userId}_${objectId}_target`];
 
-                // Envoyer une confirmation visible par tous
-                await interaction.editReply({ 
-                    content: `✅ Interaction envoyée avec **${selectedObject.name}** vers ${targetMember.displayName}!`
-                });
+                console.log(`💬 ${interaction.user.tag} a utilisé "${selectedObject.name}" sur ${targetMember.tag}: ${message}`);
 
             } catch (error) {
                 console.error('❌ Erreur lors de l\'interaction personnalisée:', error);
-                await interaction.editReply({ 
-                    content: '❌ Erreur lors de l\'envoi de l\'interaction personnalisée.' 
+                await interaction.reply({ 
+                    content: '❌ Erreur lors de l\'envoi de l\'interaction personnalisée.',
+                    ephemeral: true 
                 });
             }
         }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Simplify custom message handling for the `/objet` command to fix fragmented message display.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation used a complex and conflicting sequence of `deferReply()`, `followUp()` (via `executeCustomInteraction`), and `editReply()`, which prevented the full custom message from being displayed correctly. This change streamlines the process by directly replying with the complete custom message, ensuring proper visibility and functionality of the target ping.

---
<a href="https://cursor.com/background-agent?bcId=bc-01c879d8-7f60-4e61-acf7-993d7ad2cb90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01c879d8-7f60-4e61-acf7-993d7ad2cb90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>