### PR TITLE
Restreindre et localiser la commande /confess

### DIFF
--- a/handlers/ConfessionConfigHandler.js
+++ b/handlers/ConfessionConfigHandler.js
@@ -108,8 +108,8 @@ class ConfessionConfigHandler {
 
     async showChannelsConfig(interaction) {
         const guildId = interaction.guild.id;
-        const config = await this.dataManager.loadData('confessions.json', {});
-        const guildConfig = config[guildId] || { channels: [] };
+        const config = await this.dataManager.getData('config');
+        const guildConfig = config.confessions?.[guildId] || { channels: [] };
 
         const embed = new EmbedBuilder()
             .setColor('#2ecc71')


### PR DESCRIPTION
<!-- Restrict `/confess` command usage to configured channels and send confessions in the same channel. -->

This PR implements the user's request to limit the `/confess` command to specific channels configured via `/config-confession` and ensures the confession message is posted in the channel where the command was executed. It also includes a consistency fix in `ConfessionConfigHandler.js` to correctly load confession configurations from `config.confessions`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f8a4e69-eb0d-4f0e-bbf4-10e42dc23240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f8a4e69-eb0d-4f0e-bbf4-10e42dc23240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>