### PR TITLE
Fix shop delete and modify errors

### DIFF
--- a/handlers/EconomyConfigHandler.js
+++ b/handlers/EconomyConfigHandler.js
@@ -2140,10 +2140,10 @@ class EconomyConfigHandler {
             const embed = new EmbedBuilder()
                 .setColor('#e74c3c')
                 .setTitle('🗑️ Supprimer Objets Boutique')
-                .setDescription(`⚠️ ${guildShop.length} objet(s) à supprimer (action irréversible) :`);
+                .setDescription(`⚠️ ${guildItems.length} objet(s) à supprimer (action irréversible) :`);
 
             // Ajouter les objets existants dans l'embed
-            guildShop.slice(0, 10).forEach((item, index) => {
+            guildItems.slice(0, 10).forEach((item, index) => {
                 const icon = (item.type === 'temporary_role' || item.type === 'temp_role') ? '⌛' : 
                            (item.type === 'permanent_role' || item.type === 'perm_role') ? '⭐' : '🎨';
                 const typeText = (item.type === 'temporary_role' || item.type === 'temp_role') ? 'Rôle Temporaire' : 
@@ -2161,7 +2161,7 @@ class EconomyConfigHandler {
             ];
 
             // Ajouter les objets dans le menu de sélection
-            guildShop.slice(0, 20).forEach(item => {
+            guildItems.slice(0, 20).forEach(item => {
                 const icon = (item.type === 'temporary_role' || item.type === 'temp_role') ? '⌛' : 
                            (item.type === 'permanent_role' || item.type === 'perm_role') ? '⭐' : '🎨';
                 selectMenuOptions.push({

--- a/index.render-final.js
+++ b/index.render-final.js
@@ -1372,10 +1372,10 @@ class RenderSolutionBot {
                                 if (price >= 1 && price <= 999999) {
                                     item.price = price;
                                     
-                                    if (item.type === 'custom_object') {
+                                    if (item.type === 'custom_object' || item.type === 'custom') {
                                         item.name = interaction.fields.getTextInputValue('item_name');
                                         item.description = interaction.fields.getTextInputValue('item_description') || '';
-                                    } else if (item.type === 'temporary_role') {
+                                    } else if (item.type === 'temporary_role' || item.type === 'temp_role') {
                                         const duration = parseInt(interaction.fields.getTextInputValue('item_duration'));
                                         if (duration >= 1 && duration <= 365) {
                                             item.duration = duration;


### PR DESCRIPTION
Fixes `ReferenceError` in shop deletion and enables name modification for custom items.

The `ReferenceError` occurred because `guildShop` was used instead of the correctly defined `guildItems` in the deletion menu. The item name modification issue was due to an inconsistent type check, where the edit modal only recognized `custom_object` but not `custom` types. This PR updates the type checks to include both.

---
<a href="https://cursor.com/background-agent?bcId=bc-f06e44dc-3881-43b7-8f59-6ff44ea7b773">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f06e44dc-3881-43b7-8f59-6ff44ea7b773">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>