### PR TITLE
Vérifier le statut des modals en développement

### DIFF
--- a/utils/modalHandler.js
+++ b/utils/modalHandler.js
@@ -19,7 +19,11 @@ class ModalHandler {
             'create_negative_reward_modal',
             'custom_message_modal',
             'edit_item_modal',
-            'modify_reward_modal'
+            'modify_reward_modal',
+            // Modals du système de niveaux
+            'text_xp_modal',
+            'voice_xp_modal',
+            'level_for_role'
         ]);
 
         // Liste des modals prévues mais non implémentées
@@ -41,6 +45,12 @@ class ModalHandler {
     isModalImplemented(customId) {
         // Extraire le nom de base du modal (sans paramètres)
         const baseCustomId = customId.split('_').slice(0, 3).join('_');
+        
+        // Cas spéciaux pour les modals dynamiques de niveau
+        if (customId.startsWith('level_for_role_')) {
+            return this.implementedModals.has('level_for_role');
+        }
+        
         return this.implementedModals.has(baseCustomId);
     }
 


### PR DESCRIPTION
Register level system modals in `modalHandler` to correctly process them instead of showing 'in development' messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f7a83a0-acdd-464c-b394-2035b688d959">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f7a83a0-acdd-464c-b394-2035b688d959">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

